### PR TITLE
Pin actions to full-length commit sha

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -16,7 +16,7 @@ jobs:
     timeout-minutes: 5
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       - name: Print version
         run: swift --version


### PR DESCRIPTION
## Summary
- pin GitHub Actions checkout step to full-length commit SHA with version comment

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939c53c6cac8326a24d476883319464)